### PR TITLE
Fix Jupyter Book link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 Climate data focused PyTorch Lightning implementation of Wasserstein GANs for super-resolution. 
 
 ## Documentation
-[![Jupyter Book Badge](https://jupyterbook.org/badge.svg)](https://nannau.github.io/ClimatExML/intro.html)
+[![Jupyter Book Badge](https://jupyterbook.org/badge.svg)](https://climagination.github.io/ClimatExML/intro.html)
 
 ### Quick Start
 


### PR DESCRIPTION
Updated Jupyter Book badge link to point to the correct location where the ClimatExML documentation can be found.

Changed:
nannau[DOT]github[DOT]io -> climagination[DOT]github[DOT]io